### PR TITLE
removed initial newline to fix Synopsis pulled by Get-Help

### DIFF
--- a/InvokeBuild/about_InvokeBuild.help.txt
+++ b/InvokeBuild/about_InvokeBuild.help.txt
@@ -1,4 +1,3 @@
-﻿
 TOPIC
     about_InvokeBuild
 


### PR DESCRIPTION
Get-Help *build* will return a row for about_InvokeBuild where the "Synopsis" column lists "SHORT DESCRIPTION". This content is actually just pulled from line 5 of the about_*.help.txt file. There was an initial newline in this file that was moving Line 5 to Line 6.