### PR TITLE
invoke-taskfromISE fails if InvokeBuild is installed via module.

### DIFF
--- a/Invoke-TaskFromISE.ps1
+++ b/Invoke-TaskFromISE.ps1
@@ -58,11 +58,7 @@ $ErrorActionPreference = 'Stop'
 
 $private:ib = "$(Split-Path $MyInvocation.MyCommand.Path)\Invoke-Build.ps1"
 if (!(Test-Path -LiteralPath $ib)) {
-	$ib = 'Invoke-Build.ps1'
-    # In case Invoke-Build is installed via module.
-    if ((Get-Command $ib -ErrorAction SilentlyContinue) -eq $null) { 
-       $ib = 'Invoke-Build'
-    }
+	$ib = 'Invoke-Build'
 }
 
 $private:_Console = $Console

--- a/Invoke-TaskFromISE.ps1
+++ b/Invoke-TaskFromISE.ps1
@@ -59,6 +59,10 @@ $ErrorActionPreference = 'Stop'
 $private:ib = "$(Split-Path $MyInvocation.MyCommand.Path)\Invoke-Build.ps1"
 if (!(Test-Path -LiteralPath $ib)) {
 	$ib = 'Invoke-Build.ps1'
+    # In case Invoke-Build is installed via module.
+    if ((Get-Command $ib -ErrorAction SilentlyContinue) -eq $null) { 
+       $ib = 'Invoke-Build'
+    }
 }
 
 $private:_Console = $Console

--- a/Invoke-TaskFromVSCode.ps1
+++ b/Invoke-TaskFromVSCode.ps1
@@ -63,11 +63,7 @@ $ErrorActionPreference = 'Stop'
 
 $private:ib = "$(Split-Path $MyInvocation.MyCommand.Path)\Invoke-Build.ps1"
 if (!(Test-Path -LiteralPath $ib)) {
-	$ib = 'Invoke-Build.ps1'
-    # In case Invoke-Build is installed via module.
-    if ((Get-Command $ib -ErrorAction SilentlyContinue) -eq $null) { 
-       $ib = 'Invoke-Build'
-    }
+	$ib = 'Invoke-Build'
 }
 
 $private:_Console = $Console

--- a/Invoke-TaskFromVSCode.ps1
+++ b/Invoke-TaskFromVSCode.ps1
@@ -64,6 +64,10 @@ $ErrorActionPreference = 'Stop'
 $private:ib = "$(Split-Path $MyInvocation.MyCommand.Path)\Invoke-Build.ps1"
 if (!(Test-Path -LiteralPath $ib)) {
 	$ib = 'Invoke-Build.ps1'
+    # In case Invoke-Build is installed via module.
+    if ((Get-Command $ib -ErrorAction SilentlyContinue) -eq $null) { 
+       $ib = 'Invoke-Build'
+    }
 }
 
 $private:_Console = $Console


### PR DESCRIPTION
If you've installed InvokeBuild from the PSGallery, then the command that's in your path is Invoke-Build, not Invoke-Build.ps1. This makes the ISE and VS Code scripts compatible with that installation method.