### PR TITLE
Using temp files to avoid default graphs from overwriting one another

### DIFF
--- a/Show-BuildGraph.ps1
+++ b/Show-BuildGraph.ps1
@@ -31,8 +31,9 @@
 		See: help Invoke-Build -Parameter File
 .Parameter Output
 		The output file path and format specified by extension. For available
-		formats simply use unlikely supported one and check the error message.
-		The default is "$env:TEMP\Graphviz.pdf".
+		formats simply use a likely supported one and check the error message.
+		If not supplied, a PDF will be generated in your $env:TEMP folder with
+		a random filename like "tmpC8B4.tmp.Graphviz.pdf".
 .Parameter Code
 		Custom DOT code added to the graph definition, see Graphviz manuals.
 		The default 'graph [rankdir=LR]' tells edges to go from left to right.
@@ -57,7 +58,7 @@ param(
 	[Parameter(Position=0)]
 	[string]$File,
 	[Parameter(Position=1)]
-	[string]$Output = "$env:TEMP\Graphviz.pdf",
+	[string]$Output = [System.IO.Path]::GetTempFileName() + '.Graphviz.pdf',
 	[string]$Code = 'graph [rankdir=LR]',
 	[hashtable]$Parameters,
 	[switch]$NoShow,
@@ -126,7 +127,7 @@ $text = @(
 )
 
 #! temp file UTF8 no BOM
-$temp = "$env:TEMP\Graphviz.dot"
+$temp = [System.IO.Path]::GetTempFileName()
 [System.IO.File]::WriteAllLines($temp, $text)
 
 # make


### PR DESCRIPTION
Issue: Generating multiple graphs with default settings will cause PDFs to be generated and opened in your default PDF reader. However, the previous behavior is for the previous PDF files to be overwritten with the new one. Depending on your PDF viewer, this might be visible as multiple windows all open to the same file, that you had expected to be different.

Fix: Using unique temp files, previous PDFs will not be overwritten, so data from previous runs is preserved and any PDFs you have open will stay the way they are.