### PR TITLE
Added ability to resolve path to Build Tools installed in non-standard directory

### DIFF
--- a/Resolve-MSBuild.ps1
+++ b/Resolve-MSBuild.ps1
@@ -46,9 +46,19 @@ param(
 function Get-MSBuild15VSSetup {
 	if (Get-Module VSSetup -ListAvailable) {
 		Import-Module VSSetup
-		$vs = @(Get-VSSetupInstance | Select-VSSetupInstance -Version 15.0 -Require Microsoft.Component.MSBuild)
-		if ($vs) {
-			Join-Path ($vs[0].InstallationPath) MSBuild\15.0\Bin\MSBuild.exe
+
+		$vsInstances = @(Get-VSSetupInstance)
+		if ($vsInstances)
+		{
+			$vs = @($vsInstances | Select-VSSetupInstance -Version 15.0 -Require Microsoft.Component.MSBuild)
+			if ($vs) {
+				return Join-Path ($vs[0].InstallationPath) MSBuild\15.0\Bin\MSBuild.exe
+			}
+
+			$vsbt = @($vsInstances | Select-VSSetupInstance -Version 15.0 -Product Microsoft.VisualStudio.Product.BuildTools)
+			if ($vsbt) {
+				return Join-Path ($vsbt[0].InstallationPath) MSBuild\15.0\Bin\MSBuild.exe
+			}
 		}
 	}
 }


### PR DESCRIPTION
Select-VSSetupInstance is filtering for Visual Studio instances by default. When standalone build tools are installed, it will only find it when Product parameter with value Microsoft.VisualStudio.Product.BuildTools is specified.

This solution will prefer full VS 2017 installations but when none is found, it fall backs to the Build Toold product.

Please note that when the tools are installed to the default directory, the Get-MSBuild15Guess function will find it out correctly.