### PR TITLE
Add ability to use MSBuild from Visual Studio Preview

### DIFF
--- a/Resolve-MSBuild.ps1
+++ b/Resolve-MSBuild.ps1
@@ -73,12 +73,12 @@ function Get-MSBuild15VSSetup($Bitness) {
 	}
 }
 
-function Get-MSBuild15Guess($Bitness) {
+function Get-MSBuild15Guess($Folder, $Bitness) {
 	if (!($root = ${env:ProgramFiles(x86)})) {$root = $env:ProgramFiles}
-	if (!(Test-Path -LiteralPath "$root\Microsoft Visual Studio\2017")) {return}
+	if (!(Test-Path -LiteralPath "$root\Microsoft Visual Studio\$Folder")) {return}
 
 	$paths = @(
-		foreach($_ in Resolve-Path "$root\Microsoft Visual Studio\2017\*\$(Get-MSBuild15Path $Bitness)" -ErrorAction 0) {
+		foreach($_ in Resolve-Path "$root\Microsoft Visual Studio\$Folder\*\$(Get-MSBuild15Path $Bitness)" -ErrorAction 0) {
 			$_.ProviderPath
 		}
 	)
@@ -95,8 +95,11 @@ function Get-MSBuild15($Bitness) {
 	if ($path = Get-MSBuild15VSSetup $Bitness) {
 		$path
 	}
+	elseif ($path = Get-MSBuild15Guess "2017" $Bitness) {
+		$path
+	}
 	else {
-		Get-MSBuild15Guess $Bitness
+		Get-MSBuild15Guess "Preview" $Bitness
 	}
 }
 

--- a/Resolve-MSBuild.ps1
+++ b/Resolve-MSBuild.ps1
@@ -56,11 +56,11 @@ function Get-MSBuild15Path($Bitness) {
 	}
 }
 
-function Get-MSBuild15VSSetup($Bitness) {
+function Get-MSBuild15VSSetup([Switch] $Prerelease, $Bitness) {
 	if (!(Get-Module VSSetup -ListAvailable)) {return}
 	Import-Module VSSetup
 
-	$vs = Get-VSSetupInstance | Select-VSSetupInstance -Version 15.0 -Require Microsoft.Component.MSBuild -Product *
+	$vs = Get-VSSetupInstance -Prerelease:$Prerelease | Select-VSSetupInstance -Version 15.0 -Require Microsoft.Component.MSBuild -Product *
 	if (!$vs) {return}
 
 	$vs = if ($r = $vs | Select-VSSetupInstance -Product Microsoft.VisualStudio.Product.Enterprise) {$r}
@@ -96,6 +96,9 @@ function Get-MSBuild15($Bitness) {
 		$path
 	}
 	elseif ($path = Get-MSBuild15Guess "2017" $Bitness) {
+		$path
+	}
+	elseif ($path = Get-MSBuild15VSSetup -Prerelease $Bitness) {
 		$path
 	}
 	else {


### PR DESCRIPTION
I only have Visual Studio 2017 Preview installed, and no non-preview version of Visual Studio 2017. Currently, Resolve-MSBuild is not able to find the MSBuild 15.0 that is installed as part of Visual Studio 2017 Preview.

This PR makes Resolve-MSBuild search for MSBuild 15.0 in the Visual Studio Preview directory if it cannot find MSBuild 15.0 in the non-preview Visual Studio 2017 directory.