### PR TITLE
First attempt to implement Set-BuildFooter similar to Set-BuildHeader

### DIFF
--- a/Invoke-Build.ps1
+++ b/Invoke-Build.ps1
@@ -72,7 +72,8 @@ New-Variable * -Description IB ([PSCustomObject]@{
 	ExitTask = $null
 	EnterJob = $null
 	ExitJob = $null
-	Header = {Write-Build 11 "Task $($args[0])"}
+	Header = { Write-Build 11 "Task $($args[0])" }
+	Footer = { Write-Build 8 "Done $($args[0]) $($args[1])" }
 	Data = @{}
 	XBuild = $null
 	XTask = $null
@@ -449,7 +450,7 @@ function *Task {
 	New-Variable Task (${*}.Task = ${*}.All[${*n}]) -Option Constant
 
 	if ($Task.Elapsed) {
-		Write-Build 8 "Done ${*p}"
+		& ${*}.Footer ${*p}
 		return
 	}
 
@@ -538,7 +539,7 @@ function *Task {
 			Write-Build 14 (*At $Task)
 		}
 		else {
-			Write-Build 11 "Done ${*p} $($Task.Elapsed)"
+			& ${*}.Footer ${*p} $Task.Elapsed
 		}
 		*Run $Task.Done
 		. *Run ${*}.ExitTask
@@ -598,6 +599,7 @@ try {
 	function Enter-BuildJob([Parameter()][scriptblock]$Script) {${*}.EnterJob = $Script}
 	function Exit-BuildJob([Parameter()][scriptblock]$Script) {${*}.ExitJob = $Script}
 	function Set-BuildHeader([Parameter()][scriptblock]$Script) {${*}.Header = $Script}
+	function Set-BuildFooter([Parameter()][scriptblock]$Script) { ${*}.Footer = $Script }
 	function Set-BuildData([Parameter()]$Key, $Value) {${*}.Data[$Key] = $Value}
 
 	*SL ($BuildRoot = if ($BuildFile) {Split-Path $BuildFile} else {${*}.CD})

--- a/InvokeBuild-Help.ps1
+++ b/InvokeBuild-Help.ps1
@@ -74,7 +74,7 @@
 
 	$Task is available for script blocks defined by task parameters If, Inputs,
 	Outputs, and Jobs and by blocks Enter|Exit-BuildTask, Enter|Exit-BuildJob,
-	Set-BuildHeader.
+	Set-BuildHeader, Set-BuildFooter.
 
 		$Task properties:
 
@@ -101,6 +101,7 @@
 		Exit-BuildJob {} - after each task action
 
 		Set-BuildHeader {param($Path)} - to write task headers
+		Set-BuildFooter {param($Path)} - to write task footers
 
 	Blocks are not called on WhatIf.
 	Nested builds do not inherit parent blocks.
@@ -726,6 +727,12 @@
 		$Task.InvocationInfo.ScriptName
 		$Task.InvocationInfo.ScriptLineNumber
 	}
+				
+	Set-BuildFooter {
+		Param ($Path)
+		Write-Build Cyan "Done $Path : $(Get-BuildSynopsis $Task) - Elapsed : $($(Get-BuildSynopsis $Task).Elapsed)"
+	}
+				
 }}
 	)
 }

--- a/Tasks/Footer/Footer.build.ps1
+++ b/Tasks/Footer/Footer.build.ps1
@@ -1,0 +1,22 @@
+
+# Define footers as separator, task path, synopsis, and location, e.g. for Ctrl+Click in VSCode.
+# If you need task start times, use `$Task.Started`.
+Set-BuildFooter {
+	param($Path)
+	# separator line
+	'=' * 79
+	# default header + synopsis
+	Write-Build Cyan "Task $Path : $(Get-BuildSynopsis $Task)"
+	# task location in a script
+	Write-Build DarkGray "$($Task.InvocationInfo.ScriptName):$($Task.InvocationInfo.ScriptLineNumber)"
+}
+
+# Synopsis: Some task description 1.
+task Task1 Task2, {
+	'some output 1'
+}
+
+# Synopsis: Some task description 2.
+task Task2 {
+	'some output 2'
+}

--- a/Tasks/Footer/README.md
+++ b/Tasks/Footer/README.md
@@ -1,0 +1,23 @@
+
+## How to print more task details in task headers
+
+Invoke-Build default task headers are printed as
+
+    Task /<path>
+
+where `<path>` is a task name with its parent/calling tasks.
+
+The command `Set-BuildHeader` is used in order to use a different format and
+print additional information like task synopses, locations in build scripts,
+start times, and etc. Colored lines are written by `Write-Build`.
+
+Synopses are defined as the special comments `# Synopsis: ...` before tasks.
+Each synopsis is one line of text with short task description. It is normally
+used for getting task help by `Invoke-Build ?`. The sample shows how to use
+task synopses in task headers.
+
+Printed task locations may be useful in VSCode output window. They work like
+links, <kbd>Ctrl+Click</kbd> opens the clicked location in the editor.
+The sample shows how to use task locations in task headers.
+
+See the sample script [Header.build.ps1](Header.build.ps1).

--- a/Tests/.build.ps1
+++ b/Tests/.build.ps1
@@ -222,6 +222,7 @@ task TestFunctions {
 		'Invoke-BuildExec'
 		'Set-BuildData'
 		'Set-BuildHeader'
+		'Set-BuildFooter'
 		'Test-BuildAsset'
 		'Use-BuildAlias'
 		'Write-Build'

--- a/Tests/Footer.test.ps1
+++ b/Tests/Footer.test.ps1
@@ -1,0 +1,28 @@
+
+<#
+.Synopsis
+	Tests the sample Tasks/Footer
+
+.Example
+	Invoke-Build * Footer.test.ps1
+#>
+
+# Define footers as task path, synopsis, and location, e.g. for Ctrl+Click in VSCode
+Set-BuildFooter {
+	param($Path)
+	Write-Build Cyan "Task $Path : $(Get-BuildSynopsis $Task)"
+	Write-Build DarkGray "$($Task.InvocationInfo.ScriptName):$($Task.InvocationInfo.ScriptLineNumber)"
+}
+
+# Synopsis: Run the sample.
+task Sample {
+	($r = Invoke-Build . ../Tasks/Footer/Footer.build.ps1)
+	assert ($r -contains 'Task /Task1/Task2 : Some task description 2.')
+	assert ($r -contains 'Task /Task1 : Some task description 1.')
+}
+
+# Synopsis: Test synopsis.
+task Synopsis {
+	($r = Get-BuildSynopsis $Task)
+	equals $r 'Test synopsis.'
+}


### PR DESCRIPTION
This is my 1st attempt to implement `Set-BuildFooter` similar to `Set-BuildHeader`. so that I can get Invoke-Build it less verbose :-)

### What's probably OK
`Invoke-Build.ps1` runs perfectly and produces the same output as the original.

### What's probably not yet finished
Unfortunately, I wasn't sure what to program for the following two points.
I did my best to transfer everything from the header, but I'm very sorry I was not able to get the Pester tests running, therefore I don't know if this code is fine:

1. `InvokeBuild-Help.ps1`
I don't yet understand why / where this function `Set-BuildFooter { … }` is used.
2. As noted, all Test files are similar to the Header Test files, the content is probably not yet fine. Because I'm new to Invoke-Build (I use it for some days now). I don't know which kind of test would be perfect:
`Tasks/Footer/Footer.build.ps1`
`Tasks/Footer/README.md`
`Tests/Footer.test.ps1`

I hope that your idea for Set-BuildFooter is still a good solution for you :-)
and that you're able to find some time for a review and feedback.

Thanks a lot, kind regards,
Thomas
