### PR TITLE
Fixing positional parameter cannot be found

### DIFF
--- a/Tasks/Direct/README.md
+++ b/Tasks/Direct/README.md
@@ -8,7 +8,6 @@ Add `Tasks` as the first parameter and the command redirecting the call:
 ```powershell
 param(
     [Parameter(Position=1)]
-    [string[]]
     $Tasks,
     #... other script parameters
 )

--- a/Tasks/Direct/README.md
+++ b/Tasks/Direct/README.md
@@ -8,7 +8,7 @@ Add `Tasks` as the first parameter and the command redirecting the call:
 ```powershell
 param(
     [Parameter(Position=1)]
-	[string[]]
+    [string[]]
     $Tasks,
     #... other script parameters
 )

--- a/Tasks/Direct/README.md
+++ b/Tasks/Direct/README.md
@@ -7,7 +7,8 @@ Add `Tasks` as the first parameter and the command redirecting the call:
 
 ```powershell
 param(
-    [Parameter(Position=0)]
+    [Parameter(Position=1)]
+	[string[]]
     $Tasks,
     #... other script parameters
 )


### PR DESCRIPTION
To avoid specifying "-Tasks" parameter name each time. 
From `about_parameters`:

> Parameter Position?
    This setting indicates whether you can supply a parameter's value
    without preceding it with the parameter name. If set to "0" or "named,"
    a parameter name is required. This type of parameter is referred to as
    a named parameter. A named parameter can be listed in any position
    after the cmdlet name.


 >   If the "Parameter position?" setting is set to an integer other than 0,
    the parameter name is not required. This type of parameter is referred
    to as a positional parameter, and the number indicates the position
    in which the parameter must appear in relation to other positional
    parameters. If you include the parameter name for a positional
    parameter, the parameter can be listed in any position after the
    cmdlet name.