### PR TITLE
Fixes issue with MsBuild product sorting

### DIFF
--- a/Resolve-MSBuild.ps1
+++ b/Resolve-MSBuild.ps1
@@ -99,7 +99,7 @@ function Get-MSBuild15VSSetup {
 	if ($items.Count -ge 2) {
 		$byVersion = if ($Latest) {{$_.InstallationVersion}} else {{$_.InstallationVersion.Major}}
 		$byProduct = {
-			switch ($_.Product) {
+			switch ($_.Product.Id) {
 				Microsoft.VisualStudio.Product.Enterprise {4}
 				Microsoft.VisualStudio.Product.Professional {3}
 				Microsoft.VisualStudio.Product.Community {2}


### PR DESCRIPTION
Our team encountered an issue where our build agents (with multiple versions of Visual Studio/MSBuild installed) were selecting the wrong version of MSBuild to use.  We believe we tracked the issue down to the `$byProduct` sort in Resolve-MsBuild.ps1.  It appears that switching on the Product object is not working as expected when comparing to a string.  Updating it to compare using the Product.Id property appears to solve the issue.  Below is a screenshot of the failure to select the correct MsBuild version:

![image](https://user-images.githubusercontent.com/28988248/66605819-c8df6100-eb7e-11e9-9873-3a68a1850b83.png)

FailingExample.ps1:
```
$v = "15.0"

$byProduct = {
	switch ($_.Product) {
		Microsoft.VisualStudio.Product.Enterprise {4}
		Microsoft.VisualStudio.Product.Professional {3}
		Microsoft.VisualStudio.Product.Community {2}
		Microsoft.VisualStudio.Product.BuildTools {1}
		default {0}
	}
}

$products = Get-VSSetupInstance -Prerelease:$Prerelease | Select-VSSetupInstance -Version $v -Require Microsoft.Component.MSBuild -Product *

Write-Host "Product.ToString(): "
$products | %{ $_.Product.ToString() }
Write-Host
Write-Host "Product.Id: "
$products | %{ $_.Product.Id }
Write-Host

Write-Host "Ordered using original byProduct switch"
$sortedProducts = $products | Sort-Object $byProduct
$sortedProducts | %{ $_.Product.ToString() }

Write-Host "Resolve-MSBuild selected product: " $sortedProducts[-1].Product
Write-Host

$byProduct = {
	switch ($_.Product.Id) {
		Microsoft.VisualStudio.Product.Enterprise {4}
		Microsoft.VisualStudio.Product.Professional {3}
		Microsoft.VisualStudio.Product.Community {2}
		Microsoft.VisualStudio.Product.BuildTools {1}
		default {0}
	}
}

Write-Host "Ordered using byProduct switch with Product.Id"
$sortedProducts = $products | Sort-Object $byProduct
$sortedProducts | %{ $_.Product.ToString() }
Write-Host "Resolve-MSBuild should select product: " $sortedProducts[-1].Product
```