### PR TITLE
⚡ Add Options To New-VSCodeTask

### DIFF
--- a/New-VSCodeTask.ps1
+++ b/New-VSCodeTask.ps1
@@ -1,6 +1,6 @@
 
 <#PSScriptInfo
-.VERSION 1.1.7
+.VERSION 1.1.8
 .AUTHOR Roman Kuzmin
 .COPYRIGHT (c) Roman Kuzmin
 .TAGS Invoke, Task, Invoke-Build, VSCode
@@ -12,7 +12,6 @@
 <#
 .Synopsis
 	Makes VSCode tasks from Invoke-Build tasks
-
 .Description
 	The script creates "./.vscode/tasks.json". The existing file is replaced.
 	Change to the VSCode workspace directory before invoking the script.
@@ -33,11 +32,18 @@
 
 .Parameter BuildFile
 		Specifies the build script path, absolute or relative. By default it is
-		the default script in the current location, i.e. in the workspace root.
+        the default script in the current location, i.e. in the workspace root.
+
 .Parameter InvokeBuild
 		Specifies the Invoke-Build.ps1 path, absolute or relative. If it is not
 		specified then any found in the workspace is used. If there is none
 		then the command Invoke-Build is used.
+.Parameter OnlyJobs
+    Only generate tasks for job definitions. These are task definitions that compromise more than one individual task.
+    This is useful when you are wrap up a bunch of small tasks that need some build variables or other steps and you don't really want to call tasks by themselves, only defined sets of tasks.
+
+.Parameter Core
+    Instead of defaulting to powershell.exe, use pwsh as the executable
 
 .Example
 	> New-VSCodeTask
@@ -49,40 +55,91 @@
 	> New-VSCodeTask ./Scripts/Build.ps1 ./packages/InvokeBuild/Invoke-Build.ps1
 	This command uses relative build and engine script paths. The second may be
 	omitted, Invoke-Build.ps1 will be discovered. But it is needed if there may
-	be several Invoke-Build.ps1 in the workspace.
+    be several Invoke-Build.ps1 in the workspace.
+
+.Example
+    PS > . New-VSCodeTask ./build/build.tasks.ps1 -Core -OnlyJobs
+    This would run relative path build tasks, replace powershell.exe with pwsh.exe for Windows. Finally it would filter down the task list to
+    defined jobs instead of every individual task. This can be useful if you have a lot of small individual tasks that need to be wrapped up in jobs.
+
+    This would change the task generation behavior from including the following single item of RebuildVSCodeTask, or dev_rebuild_vscode_tasks.
+    PS> task RebuildVSCodeTask dev_rebuild_vscode_tasks
+
+    However, the following would correctly show up as it contains more than 1 task
+    PS> task RebuildVSCodeTask clean, dev_rebuild_vscode_tasks
 #>
 
 [CmdletBinding()]
 param(
-	[string]$BuildFile,
-	[string]$InvokeBuild
+    [string]$BuildFile,
+    [string]$InvokeBuild,
+    [switch]$OnlyJobs,
+    [switch]$Core
 )
 
-function Add-Text([string]$Text) {if ($args) {$out.Write($Text, $args)} else {$out.Write($Text)}}
-function Add-Line([string]$Text) {if ($args) {$out.WriteLine($Text, $args)} else {$out.WriteLine($Text)}}
+function Add-Text([string]$Text) { if ($args) { $out.Write($Text, $args) } else { $out.Write($Text) } }
+function Add-Line([string]$Text) { if ($args) { $out.WriteLine($Text, $args) } else { $out.WriteLine($Text) } }
 
-trap {$PSCmdlet.ThrowTerminatingError($_)}
+trap { $PSCmdlet.ThrowTerminatingError($_) }
 $ErrorActionPreference = 'Stop'
 
 # resolve Invoke-Build.ps1
-if (!$InvokeBuild) {
-	$InvokeBuild2 = @(Get-ChildItem . -Name -Recurse -Filter Invoke-Build.ps1)
-	$InvokeBuild = if ($InvokeBuild2) {
-		'./{0}' -f $InvokeBuild2[0]
-	} else {
-		'Invoke-Build'
-	}
+if (!$InvokeBuild)
+{
+    $InvokeBuild2 = @(Get-ChildItem . -Name -Recurse -Filter Invoke-Build.ps1)
+    $InvokeBuild = if ($InvokeBuild2)
+    {
+        './{0}' -f $InvokeBuild2[0]
+    }
+    else
+    {
+        'Invoke-Build'
+    }
 }
-$InvokeBuild2 = if ($InvokeBuild -eq 'Invoke-Build') {
-	'Invoke-Build'
+$InvokeBuild2 = if ($InvokeBuild -eq 'Invoke-Build')
+{
+    'Invoke-Build'
 }
-else {
-	"& '{0}'" -f $InvokeBuild.Replace('\', '/').Replace("'", "''")
+else
+{
+    "& '{0}'" -f $InvokeBuild.Replace('\', '/').Replace("'", "''")
 }
 
-# get all tasks and the default task
-$all = & $InvokeBuild ?? -File $BuildFile
-$dot = if ($all['.']) {'.'} else {$all.Item(0).Name}
+
+
+if ($OnlyJobs)
+{
+####################################################
+# If Requesting Only Jobs Then Filter Down Results #
+#  To Just Those Containing More Than 1 Job Item   #
+####################################################
+    Write-Verbose "Filtering tasks to jobs containing more than 1 defined task in them"
+    $all = (& $InvokeBuild ?? -File $BuildFile | Where-Object { @($_.Values.GetEnumerator().Jobs).Count -gt 1 }).GetEnumerator() | ForEach-Object {
+        $v = $_
+        $v.value  | Add-Member -NotePropertyName JobCount -NotePropertyValue (@($v.Value.Jobs).Count) -PassThru
+    } | Where-Object { $_.JobCount -gt 1} | ForEach-Object {
+        $i = $_
+        $ht = @{ }
+        $i.psobject.properties | ForEach-Object { $ht[$_.Name] = $_.Value }
+        [hashtable]$Final = @{}
+        $final.Add($i.Name, $ht)
+        $final
+    }
+    Write-Verbose "$(@($All).Count) tasks discovered"
+}
+else
+{
+    ##############################
+    # Default Behavior All Tasks #
+    ##############################
+    Write-Verbose "No filtering applied to task list. All discovered tasks included"
+    $all = & $InvokeBuild ?? -File $BuildFile
+    Write-Verbose "$(@($All).Count) tasks discovered"
+}
+
+
+
+$dot = if ($all['.']) { '.' } else { $all.Item(0).Name }
 
 # tasks.json header
 $out = New-Object System.IO.StringWriter
@@ -94,8 +151,8 @@ Add-Line '  "version": "2.0.0",'
 Add-Line '  "windows": {'
 Add-Line '    "options": {'
 Add-Line '      "shell": {'
-Add-Line '        "executable": "powershell.exe",'
-Add-Line '        "args": [ "-NoProfile", "-ExecutionPolicy", "Bypass", "-Command" ]'
+Add-Line ('        "executable": "{0}",' -f @('powershell.exe', 'pwsh.exe')[[bool]$core])
+Add-Line '        "args": [ "-NoProfile", "-NoLogo","-ExecutionPolicy", "Bypass", "-Command" ]'
 Add-Line '      }'
 Add-Line '    }'
 Add-Line '  },'
@@ -118,24 +175,30 @@ Add-Line '  },'
 Add-Line '  "tasks": ['
 
 # tasks.json tasks
-$BuildFile2 = if ($BuildFile) {" -File '{0}'" -f $BuildFile.Replace('\', '/').Replace("'", "''")} else {''}
-foreach($task in $all.Values) {
-	$name = $task.Name
-	if ($name -match '[^\w\.\-]|^-') {
-		continue
-	}
-	Add-Line '    {'
-	Add-Line '      "label": "{0}",' $name
-	Add-Line '      "type": "shell",'
-	Add-Line '      "problemMatcher": [ "$msCompile" ],'
-	if ($name -eq $dot) {
-		Add-Line '      "group": {'
-		Add-Line '        "kind": "build",'
-		Add-Line '        "isDefault": true'
-		Add-Line '      },'
-	}
-	Add-Line '      "command": "{0} -Task {1}{2}"' $InvokeBuild2 $name $BuildFile2
-	Add-Line '    },'
+$BuildFile2 = if ($BuildFile) { " -File '{0}'" -f $BuildFile.Replace('\', '/').Replace("'", "''") } else { '' }
+
+
+
+foreach ($task in $all.Values)
+{
+    $name = $task.Name
+    if ($name -match '[^\w\.\-]|^-')
+    {
+        continue
+    }
+    Add-Line '    {'
+    Add-Line '      "label": "{0}",' $name
+    Add-Line '      "type": "shell",'
+    Add-Line '      "problemMatcher": [ "$msCompile" ],'
+    if ($name -eq $dot)
+    {
+        Add-Line '      "group": {'
+        Add-Line '        "kind": "build",'
+        Add-Line '        "isDefault": true'
+        Add-Line '      },'
+    }
+    Add-Line '      "command": "{0} -Task {1}{2}"' $InvokeBuild2 $name $BuildFile2
+    Add-Line '    },'
 }
 
 # last task and ending
@@ -149,14 +212,17 @@ Add-Line '  ]'
 Add-Text '}'
 
 # save the file
-if (!(Test-Path .vscode)) {
-	$null = mkdir .vscode
+if (!(Test-Path .vscode))
+{
+    $null = mkdir .vscode
 }
-elseif (Test-Path ./.vscode/tasks.json) {
-	$line1, $null = Get-Content ./.vscode/tasks.json
-	if ($line1 -ne $Header) {
-		Remove-Item ./.vscode/tasks.json -Confirm
-		if (Test-Path ./.vscode/tasks.json) {return}
-	}
+elseif (Test-Path ./.vscode/tasks.json)
+{
+    $line1, $null = Get-Content ./.vscode/tasks.json
+    if ($line1 -ne $Header)
+    {
+        Remove-Item ./.vscode/tasks.json -Confirm
+        if (Test-Path ./.vscode/tasks.json) { return }
+    }
 }
 Set-Content ./.vscode/tasks.json $out.ToString() -Encoding UTF8


### PR DESCRIPTION

✨ Added switch for core/powershell.exe choice using `-Core` for core, and by default using powershell.exe.
✨ Added switch `-OnlyJobs` for only generating task lists for jobs with more than 1 task defined in them
🧹Added `-NoLogo` to default powershell arguments
⬆ Bumped version to `1.1.8`
📃 Add documentation for new parameters, and examples