### PR TITLE
Execute Invoke-Build via -File parameter in ib.cmd, to make Invoke-Bu…

### DIFF
--- a/ib.cmd
+++ b/ib.cmd
@@ -7,13 +7,14 @@
 if "%1"=="?" goto list
 if "%1"=="/?" goto help
 
-powershell.exe -NoProfile -ExecutionPolicy Bypass -Command "& '%~dp0Invoke-Build.ps1' %*"
+rem Dot-source Invoke-Build first, so that it will be available in script block closures (#160)
+powershell.exe -NoProfile -ExecutionPolicy Bypass -Command ". '%~dp0Invoke-Build.ps1'; Invoke-Build %*"
 exit /B %errorlevel%
 
 :list
-powershell.exe -NoProfile -ExecutionPolicy Bypass -Command "& '%~dp0Invoke-Build.ps1' %* | Format-Table -AutoSize"
+powershell.exe -NoProfile -ExecutionPolicy Bypass -Command ". '%~dp0Invoke-Build.ps1'; Invoke-Build %* | Format-Table -AutoSize"
 exit /B 0
 
 :help
-powershell.exe -NoProfile -ExecutionPolicy Bypass -Command "help -Full '%~dp0Invoke-Build.ps1'"
+powershell.exe -NoProfile -ExecutionPolicy Bypass -Command "Get-Help -Full '%~dp0Invoke-Build.ps1'"
 exit /B 0


### PR DESCRIPTION
…ild available in closures

Without this change build script like below will crash with "ERROR: The term 'exec' is not recognized as the name of a cmdlet, function, script file, or operable program.":

```powershell
@("Alice", "Bob", "Charlie") | ForEach-Object {
  $taskName = $PSItem
  task "Hello$taskName" {
    exec { cmd /c "echo Hello $taskName" }
    # GetNewClosure() is required to mimic real closures in PowerShell
  }.GetNewClosure()
}
# And run like: ib HelloBob
```

As far I understand it, the `-File`  will 'dot-source' Invoke-Build, so it will be later copied to the GetNewClosure()-generated module.