### PR TITLE
Fix detection of VS 2022/2026 Build Tools when VSSetup not present

### DIFF
--- a/Resolve-MSBuild.ps1
+++ b/Resolve-MSBuild.ps1
@@ -156,15 +156,19 @@ function Get-MSBuild15Guess {
 		}
 		elseif ($Version -eq '*') {
 			"$Program64\Microsoft Visual Studio\18"
+			"$Program86\Microsoft Visual Studio\18"
 			"$Program64\Microsoft Visual Studio\2022"
+			"$Program86\Microsoft Visual Studio\2022"
 			"$Program86\Microsoft Visual Studio\2019"
 			"$Program86\Microsoft Visual Studio\2017"
 		}
 		elseif ($Version -eq '18.0') {
 			"$Program64\Microsoft Visual Studio\18"
+			"$Program86\Microsoft Visual Studio\18"
 		}
 		elseif ($Version -eq '17.0') {
 			"$Program64\Microsoft Visual Studio\2022"
+			"$Program86\Microsoft Visual Studio\2022"
 		}
 		elseif ($Version -eq '16.0') {
 			"$Program86\Microsoft Visual Studio\2019"


### PR DESCRIPTION
There is a regression in https://github.com/nightroman/Invoke-Build/commit/a7ed5d2719a15057aadb3713fc2681eee7e12fc9 causing Visual Studio Build Tools 2022 to not be found when then VSSetup module is not present. This is due to the Build Tools installing to Program Files (x86) by default, rather than Program Files. The same issue also occurs with the 2026 version in the newly added support for that. The result is the ancient .NET Framework msbuild getting picked up instead.

This change falls back to Program Files (x86) for both affected versions if a corresponding install cannot be found in Program Files.